### PR TITLE
Support waiting for containers to exit before continuing.

### DIFF
--- a/duct.go
+++ b/duct.go
@@ -163,6 +163,7 @@ func (c *Composer) GetNetworkID() string {
 	return c.netID
 }
 
+// internal variable for testing and capturing log dumping from containers
 var containerLogsTarget io.Writer = os.Stdout
 
 // Launch launches the manifest. On error containers are automatically cleaned

--- a/duct_test.go
+++ b/duct_test.go
@@ -402,6 +402,6 @@ func TestWaitForExit(t *testing.T) {
 	}, WithNewNetwork("duct-test-network"))
 
 	if err := c.Launch(context.Background()); err == nil {
-		t.Fatal("Expected error due to bad exit code", err)
+		t.Fatal("Expected error due to bad exit code, but none occurred")
 	}
 }

--- a/duct_test.go
+++ b/duct_test.go
@@ -372,3 +372,36 @@ func TestLoggerOption(t *testing.T) {
 		t.Fatal("Didn't capture logs")
 	}
 }
+
+func TestWaitForExit(t *testing.T) {
+
+	c := New(Manifest{
+		{
+			Name:        "Exit",
+			Command:     []string{"sleep", "1"},
+			Image:       "debian:latest",
+			WaitForExit: true,
+		},
+	}, WithNewNetwork("duct-test-network"))
+
+	if err := c.Launch(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := c.Teardown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	c = New(Manifest{
+		{
+			Name:        "ExitBadly",
+			Command:     []string{"ls", "-123"},
+			Image:       "debian:latest",
+			WaitForExit: true,
+		},
+	}, WithNewNetwork("duct-test-network"))
+
+	if err := c.Launch(context.Background()); err == nil {
+		t.Fatal("Expected error due to bad exit code", err)
+	}
+}

--- a/duct_test.go
+++ b/duct_test.go
@@ -367,7 +367,6 @@ func TestLoggerOption(t *testing.T) {
 	}
 
 	logs := buffer.String()
-	t.Log(logs)
 	if len(logs) == 0 {
 		t.Fatal("Didn't capture logs")
 	}
@@ -401,7 +400,20 @@ func TestWaitForExit(t *testing.T) {
 		},
 	}, WithNewNetwork("duct-test-network"))
 
+	oldTarget := containerLogsTarget
+	defer func() {
+		containerLogsTarget = oldTarget
+	}()
+
+	buffer := &bytes.Buffer{}
+	containerLogsTarget = buffer
+
 	if err := c.Launch(context.Background()); err == nil {
 		t.Fatal("Expected error due to bad exit code, but none occurred")
+	}
+
+	logs := buffer.String()
+	if len(logs) == 0 {
+		t.Fatal("Didn't capture logs")
 	}
 }

--- a/duct_test.go
+++ b/duct_test.go
@@ -338,7 +338,6 @@ func TestWithExistingNetwork(t *testing.T) {
 }
 
 func TestLoggerOption(t *testing.T) {
-
 	buffer := &bytes.Buffer{}
 
 	c := New(Manifest{
@@ -377,7 +376,7 @@ func TestWaitForExit(t *testing.T) {
 	c := New(Manifest{
 		{
 			Name:        "Exit",
-			Command:     []string{"sleep", "1"},
+			Command:     []string{"sh", "-c", "sleep 1"},
 			Image:       "debian:latest",
 			WaitForExit: true,
 		},
@@ -394,26 +393,13 @@ func TestWaitForExit(t *testing.T) {
 	c = New(Manifest{
 		{
 			Name:        "ExitBadly",
-			Command:     []string{"ls", "-123"},
+			Command:     []string{"sh", "-c", "exit 1"},
 			Image:       "debian:latest",
 			WaitForExit: true,
 		},
 	}, WithNewNetwork("duct-test-network"))
 
-	oldTarget := containerLogsTarget
-	defer func() {
-		containerLogsTarget = oldTarget
-	}()
-
-	buffer := &bytes.Buffer{}
-	containerLogsTarget = buffer
-
 	if err := c.Launch(context.Background()); err == nil {
 		t.Fatal("Expected error due to bad exit code, but none occurred")
-	}
-
-	logs := buffer.String()
-	if len(logs) == 0 {
-		t.Fatal("Didn't capture logs")
 	}
 }

--- a/test.sh
+++ b/test.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-killdocker() {
-  pkill dockerd
-}
-
-trap killdocker INT HUP TERM
-
 nohup dockerd -s vfs &
 
 curl -sSL https://storage.googleapis.com/golang/go${GOLANG_VERSION:-1.15.7}.linux-amd64.tar.gz | tar -xz -C /usr/local


### PR DESCRIPTION
Example scenario: some containers run DB init scripts, setup data, etc.

This adds a field which allows waiting for a container until it completes.

Manifest example:

* Container 1: Postgres
* Container 2 (WaitForExit), postgres init scripts, then exits
* Container 3: Service that uses (1)

```
c := New(Manifest{
		{
			Name:        "Exit",
			Command:     []string{"sleep", "1"},
			Image:       "debian:latest",
			WaitForExit: true,
		},
	}, WithNewNetwork("duct-test-network"))
```

If the process exits with a non-zero exit code, Duct will return a error.

