### PR TITLE
Fix the build test

### DIFF
--- a/build_test.go
+++ b/build_test.go
@@ -28,11 +28,11 @@ func TestBuild(t *testing.T) {
 		},
 	}, WithNewNetwork("duct-test-network"))
 
-	if err := c.Launch(context.Background()); err != nil {
-		t.Fatal(err)
-	}
+	t.Cleanup(func() {
+		c.Teardown(context.Background())
+	})
 
-	if err := c.Teardown(context.Background()); err != nil {
+	if err := c.Launch(context.Background()); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/testdata/Dockerfile.test
+++ b/testdata/Dockerfile.test
@@ -1,2 +1,2 @@
 FROM alpine
-CMD true
+CMD /bin/true


### PR DESCRIPTION
This was caused becuase the container was exiting too fast.

Signed-off-by: Erik Hollensbe <github@hollensbe.org>